### PR TITLE
Don't break older versions of Dockstore CLI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <plugin.id>${project.artifactId}</plugin.id>
         <plugin.class>io.dockstore.provision.DOSPlugin</plugin.class>
         <plugin.version>${project.version}</plugin.version>
+        <plugin.requires>&gt;0.0.0</plugin.requires> <!-- 0.0.1 is Dockstore 1.5, which has PreProvisionInterface-->
         <plugin.provider>Ryan Bautista</plugin.provider>
         <plugin.dependencies/>
     </properties>
@@ -101,6 +102,7 @@
                             <Plugin-Version>${plugin.version}</Plugin-Version>
                             <Plugin-Provider>${plugin.provider}</Plugin-Provider>
                             <Plugin-Dependencies>${plugin.dependencies}</Plugin-Dependencies>
+                            <Plugin-Requires>${plugin.requires}</Plugin-Requires>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
ga4gh/dockstore#1629

One half of fix to not break older versions of Dockstore CLI when
this plugin is present in the ~/.dockstore/plugins directory.

In version 1.4 and earlier of Dockstore CLI
`VersionAwarePluginManager.getSystemVersion()` returns a Version
that represents `0.0.0`, the default; by specifying that this
plugin version requires >0.0.0. An upcoming PR to Dockstore Client
will change that version to 0.0.1.

When Dockstore CLI 1.4 runs, it will not attempt to load this plugin,
because of the requires requirement.

Fortunately, we are using an older version of the PF4J, as the
more recent versions interpret the 0.0.0 system version to mean
load all plugins without checking the version.