### PR TITLE
Feature/config-preference-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/dockstore/data-object-service-plugin.svg?branch=master)](https://travis-ci.org/dockstore/data-object-service-plugin)
-[![Coverage Status](https://coveralls.io/repos/github/dockstore/data-object-service-plugin/badge.svg?branch=master)](https://coveralls.io/github/dockstore/data-object-service-plugin?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/dockstore/data-object-service-plugin/badge.svg?branch=develop)](https://coveralls.io/github/dockstore/data-object-service-plugin?branch=develop)
 
 # data-object-service-plugin
 [Dockstore Data Object Service](https://github.com/ga4gh/data-object-service-schemas) file preprovisioning plugin
@@ -47,7 +47,11 @@ Downloading: file:///./datastore/launcher-2c670320-9ade-4f9d-9e54-3eff66c29e8d/o
 scheme-preference = s3, gs, synapse
 ```
 
-You can also specify an ordering of preferred schemes for any provided DOS URI in your system's `.dockstore/config` file.
+You can optionally specify the order of preferred schemes for DOS URI's in your system's `~/.dockstore/config` file. The scheme precedence is
+ordered from highest (left-most) to lowest (right-most).
+
+Leaving out `scheme-preference` from your system's `~/.dockstore/config` file means that DOS URI's will be resolved by
+calling on the first valid Dockstore plugin locally-installed on your system.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Provisioning from ./datastore/launcher-2c670320-9ade-4f9d-9e54-3eff66c29e8d/outp
 Downloading: file:///./datastore/launcher-2c670320-9ade-4f9d-9e54-3eff66c29e8d/outputs/md5sum.txt to file:///tmp/md5sum.txt
 ```
 
+### The Config File
+
+```
+[dockstore-file-dos-plugin]
+scheme-preference = s3, gs, synapse
+```
+
+You can also specify an ordering of preferred schemes for any provided DOS URI in your system's `.dockstore/config` file.
+
 ## Releases
 
 This section describes creating a release of the Data Object Service plugin.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,18 @@ Downloading: file:///./datastore/launcher-2c670320-9ade-4f9d-9e54-3eff66c29e8d/o
 scheme-preference = s3, gs, synapse
 ```
 
-You can optionally specify the order of preferred schemes for DOS URI's in your system's `~/.dockstore/config` file. The scheme precedence is
-ordered from highest (left-most) to lowest (right-most).
+A basic Dockstore configuration file is available/should be created in `~/.dockstore/config`.
+By default, Dockstore attempts to download the first URL whose scheme is supported by one of your locally-installed Dockstore
+file provisioning plugins.
 
-Leaving out `scheme-preference` from your system's `~/.dockstore/config` file means that DOS URI's will be resolved by
-calling on the first valid Dockstore plugin locally-installed on your system.
+You can override the default behavior by configuring the Data-Object-Service plugin with the `scheme-preference` option.
+`scheme-preference` lets you specify your preferred order of schemes that the Data Object Service plugin will use to order the
+resolved data objects from a provided DOS URI.
+
+Dockstore will attempt to download the first URL from the ordered list whose scheme is supported by one of your
+locally-installed Dockstore file provisioning plugins.
+
+Omitting `scheme-preference` from `~/.dockstore/config` returns Dockstore to the default behavior for resolving DOS URIs, as described above.
 
 ## Releases
 
@@ -59,7 +66,7 @@ This section describes creating a release of the Data Object Service plugin.
 
 ### Prerequisites
 
-[Install](https://datasift.github.io/gitflow/TheHubFlowTools.html) Hubflow. After it is installed, run `git hubflow init` in the 
+[Install](https://datasift.github.io/gitflow/TheHubFlowTools.html) Hubflow. After it is installed, run `git hubflow init` in the
 root of your copy of the repo.
 
 ### Create the Release
@@ -91,14 +98,14 @@ Then do `git hf release finish 0.0.4`, which will
 
 1. In your browser, go to https://github.com/dockstore/data-object-service-plugin/releases
 2. You will see `0.0.4` listed, but it is *not* a GitHub release, it is a only tag. All GitHub releases have Git tags, but not all Git tags
-are  GitHub releases, even though the GitHub UI Releases tab doesn't clearly make that distinction. See 
+are  GitHub releases, even though the GitHub UI Releases tab doesn't clearly make that distinction. See
  [this issue](https://github.com/bcit-ci/CodeIgniter/issues/3421).
 3. Create a GitHub 0.0.4 release
     1. Click `Draft (or Create) a new release`.
     2. Specify the tag, `0.0.4`
-    3. Attach the zip file from your local target directory, which will have the version number in it, e.g., 
+    3. Attach the zip file from your local target directory, which will have the version number in it, e.g.,
     dockstore-file-dos-plugin-0.0.4.zip, to the binaries section of the page.
     4. Enter a title and a description.
     5. Click `Publish Release`
-    
- 
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.6.0-alpha.1-SNAPSHOT</version>
+            <version>1.6.0-alpha.0</version>
             <!-- !!! VERY IMPORTANT -->
             <!-- Version number should be changed to current version of dockstore-->
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.5</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -217,6 +222,10 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>dockstore-file-dos-plugin</artifactId>
     <packaging>jar</packaging>
     <name>dockstore-file-dos-plugin</name>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
 
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>dockstore-file-dos-plugin</artifactId>
     <packaging>jar</packaging>
     <name>dockstore-file-dos-plugin</name>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
 
 
     <properties>
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.5.0-alpha.2</version>
+            <version>1.5.1</version>
             <!-- !!! VERY IMPORTANT -->
             <!-- Version number should be changed to current version of dockstore-->
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <plugin.id>${project.artifactId}</plugin.id>
         <plugin.class>io.dockstore.provision.DOSPlugin</plugin.class>
         <plugin.version>${project.version}</plugin.version>
-        <plugin.requires>&gt;0.0.1</plugin.requires> <!-- 0.0.2 is Dockstore 1.6, which has udpated PreProvisionInterface-->
+        <plugin.requires>&gt;0.0.1</plugin.requires> <!-- 0.0.2 is Dockstore 1.6, which has updated PreProvisionInterface-->
         <plugin.provider>Ryan Bautista</plugin.provider>
         <github.url>scm:git:git@github.com:dockstore/data-object-service-plugin.git</github.url>
         <plugin.dependencies />
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.6.0-alpha.0-SNAPSHOT</version>
+            <version>1.6.0-alpha.1-SNAPSHOT</version>
             <!-- !!! VERY IMPORTANT -->
             <!-- Version number should be changed to current version of dockstore-->
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>dockstore-file-dos-plugin</artifactId>
     <packaging>jar</packaging>
     <name>dockstore-file-dos-plugin</name>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
 
 
     <properties>
@@ -14,7 +14,7 @@
         <plugin.id>${project.artifactId}</plugin.id>
         <plugin.class>io.dockstore.provision.DOSPlugin</plugin.class>
         <plugin.version>${project.version}</plugin.version>
-        <plugin.requires>&gt;0.0.0</plugin.requires> <!-- 0.0.1 is Dockstore 1.5, which has PreProvisionInterface-->
+        <plugin.requires>&gt;0.0.1</plugin.requires> <!-- 0.0.2 is Dockstore 1.6, which has udpated PreProvisionInterface-->
         <plugin.provider>Ryan Bautista</plugin.provider>
         <github.url>scm:git:git@github.com:dockstore/data-object-service-plugin.git</github.url>
         <plugin.dependencies />
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>dockstore-file-plugin-parent</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.0-alpha.0-SNAPSHOT</version>
             <!-- !!! VERY IMPORTANT -->
             <!-- Version number should be changed to current version of dockstore-->
             <scope>provided</scope>

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -53,7 +53,8 @@ public class DOSPlugin extends Plugin {
     public static class DOSPreProvision implements PreProvisionInterface {
 
         static final Set<String> SCHEME = new HashSet<>(Lists.newArrayList("dos"));
-        public static final String SCHEME_PREFERENCE = "scheme-preference";
+        static final String SCHEME_PREFERENCE = "scheme-preference";
+        static final int GET_SCHEME = 0;
         private Map<String, String> config;
 
         DOSPluginUtil dosPluginUtil = new DOSPluginUtil();
@@ -75,6 +76,7 @@ public class DOSPlugin extends Plugin {
         public List<String> prepareDownload(String targetPath) {
             List<String> urlList = new ArrayList<>();
             Map<String, List<String>> urlMap = new LinkedHashMap<>();
+            String protocol = ":\\/\\/(.+)/";
 
             Optional<ImmutableTriple<String, String, String>> uri = dosPluginUtil.splitURI(targetPath);
 
@@ -87,7 +89,7 @@ public class DOSPlugin extends Plugin {
                     // Place all URLs into map for fast lookup time. URLs with duplicate schemes are appended to existing entry
                     for (int i = 0; i < urls.length(); i++) {
                         String url = urls.getJSONObject(i).getString("url");
-                        String scheme = url.split(":\\/\\/(.+)/")[0];
+                        String scheme = url.split(protocol)[GET_SCHEME];
                         if (urlMap.containsKey(scheme)) {
                             urlMap.get(scheme).add(url);
                         } else {

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -49,17 +49,18 @@ public class DOSPlugin extends Plugin {
     @Extension
     public static class DOSPreProvision implements PreProvisionInterface {
 
+        DOSPluginUtil pluginUtil = new DOSPluginUtil();
+
         public Set<String> schemesHandled() {
             return new HashSet<>(Lists.newArrayList("dos"));
         }
 
         public List<String> prepareDownload(String targetPath) {
-            DOSPluginUtil pluginUtil = new DOSPluginUtil();
             List<String> urlList = new ArrayList<>();
-            Optional<ImmutableTriple<String, String, String>> uri = pluginUtil.splitUri(targetPath);
+            Optional<ImmutableTriple<String, String, String>> uri = pluginUtil.splitURI(targetPath);
 
             if (uri.isPresent() && schemesHandled().contains(uri.get().getLeft())) {
-                Optional<JSONObject> jsonObj = pluginUtil.grabJSON(uri.get());
+                Optional<JSONObject> jsonObj = pluginUtil.getResponse(uri.get());
 
                 if(jsonObj.isPresent()) {
                     JSONArray urls = jsonObj.get().getJSONObject("data_object").getJSONArray("urls");

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -65,7 +65,7 @@ public class DOSPlugin extends Plugin {
             this.config = map;
 
             if (this.config.containsKey(SCHEME_PREFERENCE)) {
-                this.preferredSchemes = Arrays.asList(this.config.get(SCHEME_PREFERENCE).trim().split(",\\s"));
+                this.preferredSchemes = Arrays.asList(this.config.get(SCHEME_PREFERENCE).trim().split(",\\s*"));
             }
         }
 
@@ -75,7 +75,7 @@ public class DOSPlugin extends Plugin {
 
         public List<String> prepareDownload(String targetPath) {
             List<String> urlList = new ArrayList<>();
-            Map<String, List<String>> urlMap = new LinkedHashMap<>();
+            Map<String, List<String>> urlMap = new LinkedHashMap<>();       // Linked Hash Maps ensure insertion-ordered key-value pairs
             String protocol = ":\\/\\/(.+)/";
 
             Optional<ImmutableTriple<String, String, String>> uri = dosPluginUtil.splitURI(targetPath);

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -1,5 +1,14 @@
 package io.dockstore.provision;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
@@ -9,15 +18,6 @@ import ro.fortsoft.pf4j.Extension;
 import ro.fortsoft.pf4j.Plugin;
 import ro.fortsoft.pf4j.PluginWrapper;
 import ro.fortsoft.pf4j.RuntimeMode;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 
 public class DOSPlugin extends Plugin {
@@ -75,7 +75,10 @@ public class DOSPlugin extends Plugin {
 
         public List<String> prepareDownload(String targetPath) {
             List<String> urlList = new ArrayList<>();
-            Map<String, List<String>> urlMap = new LinkedHashMap<>();       // Linked Hash Maps ensure insertion-ordered key-value pairs
+
+            // Linked Hash Maps ensure insertion-ordered key-value pairs. URLs resolved by the plugin are
+            // inserted by scheme (key) and a list of that scheme's URL(s) (value)
+            Map<String, List<String>> urlMap = new LinkedHashMap<>();
             String protocol = ":\\/\\/(.+)/";
 
             Optional<ImmutableTriple<String, String, String>> uri = dosPluginUtil.splitURI(targetPath);

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -49,7 +49,7 @@ public class DOSPlugin extends Plugin {
     @Extension
     public static class DOSPreProvision implements PreProvisionInterface {
 
-        static final DOSPluginUtil DOS_PLUGIN_UTIL = new DOSPluginUtil();
+        DOSPluginUtil dosPluginUtil = new DOSPluginUtil();
         static final Set<String> SCHEME = new HashSet<>(Lists.newArrayList("dos"));
 
         public Set<String> schemesHandled() {
@@ -58,10 +58,10 @@ public class DOSPlugin extends Plugin {
 
         public List<String> prepareDownload(String targetPath) {
             List<String> urlList = new ArrayList<>();
-            Optional<ImmutableTriple<String, String, String>> uri = DOS_PLUGIN_UTIL.splitURI(targetPath);
+            Optional<ImmutableTriple<String, String, String>> uri = dosPluginUtil.splitURI(targetPath);
 
             if (uri.isPresent() && schemesHandled().contains(uri.get().getLeft())) {
-                Optional<JSONObject> jsonObj = DOS_PLUGIN_UTIL.getResponse(uri.get());
+                Optional<JSONObject> jsonObj = dosPluginUtil.getResponse(uri.get());
 
                 if(jsonObj.isPresent()) {
                     JSONArray urls = jsonObj.get().getJSONObject("data_object").getJSONArray("urls");

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -64,8 +64,12 @@ public class DOSPlugin extends Plugin {
         public void setConfiguration(Map<String, String> map) {
             this.config = map;
 
+            // Parse the preferred schemes into a list by splitting on commas and extra spaces, and remove all empty strings from the list
             if (this.config.containsKey(SCHEME_PREFERENCE)) {
-                this.preferredSchemes = Arrays.asList(this.config.get(SCHEME_PREFERENCE).trim().split(",\\s*"));
+
+                // Arrays.asList returns a fixed-sized array, so wrapping it as an ArrayList object allows list modification
+                this.preferredSchemes = new ArrayList<>(Arrays.asList(this.config.get(SCHEME_PREFERENCE).trim().split(",\\s*")));
+                this.preferredSchemes.removeIf(e -> e.equals(""));
             }
         }
 

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -55,7 +55,7 @@ public class DOSPlugin extends Plugin {
 
         public List<String> prepareDownload(String targetPath) {
             DOSPluginUtil pluginUtil = new DOSPluginUtil();
-            List<String> url_list = new ArrayList<>();
+            List<String> urlList = new ArrayList<>();
             Optional<ImmutableTriple<String, String, String>> uri = pluginUtil.splitUri(targetPath);
 
             if (uri.isPresent() && schemesHandled().contains(uri.get().getLeft())) {
@@ -64,11 +64,11 @@ public class DOSPlugin extends Plugin {
                 if(jsonObj.isPresent()) {
                     JSONArray urls = jsonObj.get().getJSONObject("data_object").getJSONArray("urls");
                     for (int i = 0; i < urls.length(); i++) {
-                        url_list.add(urls.getJSONObject(i).getString("url"));
+                        urlList.add(urls.getJSONObject(i).getString("url"));
                     }
                 }
             }
-            return url_list;
+            return urlList;
         }
     }
 }

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -49,18 +49,19 @@ public class DOSPlugin extends Plugin {
     @Extension
     public static class DOSPreProvision implements PreProvisionInterface {
 
-        DOSPluginUtil pluginUtil = new DOSPluginUtil();
+        static final DOSPluginUtil DOS_PLUGIN_UTIL = new DOSPluginUtil();
+        static final Set<String> SCHEME = new HashSet<>(Lists.newArrayList("dos"));
 
         public Set<String> schemesHandled() {
-            return new HashSet<>(Lists.newArrayList("dos"));
+            return SCHEME;
         }
 
         public List<String> prepareDownload(String targetPath) {
             List<String> urlList = new ArrayList<>();
-            Optional<ImmutableTriple<String, String, String>> uri = pluginUtil.splitURI(targetPath);
+            Optional<ImmutableTriple<String, String, String>> uri = DOS_PLUGIN_UTIL.splitURI(targetPath);
 
             if (uri.isPresent() && schemesHandled().contains(uri.get().getLeft())) {
-                Optional<JSONObject> jsonObj = pluginUtil.getResponse(uri.get());
+                Optional<JSONObject> jsonObj = DOS_PLUGIN_UTIL.getResponse(uri.get());
 
                 if(jsonObj.isPresent()) {
                     JSONArray urls = jsonObj.get().getJSONObject("data_object").getJSONArray("urls");

--- a/src/main/java/io/dockstore/provision/DOSPlugin.java
+++ b/src/main/java/io/dockstore/provision/DOSPlugin.java
@@ -70,8 +70,7 @@ public class DOSPlugin extends Plugin {
             config.setListDelimiterHandler(new DefaultListDelimiterHandler(','));
 
             // Retrieve the scheme preferences from the config file
-            this.preferredSchemes = config.containsKey(SCHEME_PREFERENCE) ?
-                    config.getList(String.class, SCHEME_PREFERENCE) : new ArrayList<>();
+            this.preferredSchemes = config.getList(String.class, SCHEME_PREFERENCE, Collections.emptyList());
             // Remove any empty strings from the list
             this.preferredSchemes.removeIf(e -> e.equals(""));
         }

--- a/src/main/java/io/dockstore/provision/DOSPluginUtil.java
+++ b/src/main/java/io/dockstore/provision/DOSPluginUtil.java
@@ -47,8 +47,8 @@ class DOSPluginUtil {
             // or the new format
             // dos://dg.4503/630d31c3-381e-488d-b639-ce5d047a0142
             // See if the Host portion starts with 'dg' and ends with a port number
-            List<String> host_split = Lists.newArrayList(split.get(HOST).split("\\.", 2));
-            if (host_split.size() > 1 && host_split.get(0).equals("dg") && NumberUtils.isNumber(host_split.get(1))) {
+            List<String> hostSplit = Lists.newArrayList(split.get(HOST).split("\\.", 2));
+            if (hostSplit.size() > 1 && hostSplit.get(0).equals("dg") && NumberUtils.isNumber(hostSplit.get(1))) {
                 return Optional.of(new ImmutableTriple<>(split.get(SCHEME), DG_HOST, split.get(DG_PREFIX) + "/" + split.get(DG_UUID)));
             }
             return Optional.of(new ImmutableTriple<>(split.get(SCHEME), split.get(HOST), split.get(PATH)));
@@ -77,8 +77,7 @@ class DOSPluginUtil {
             }
 
         } catch (JSONException e) {
-            System.err.println("getResponse() Error: " + e.getMessage());
-            e.printStackTrace();
+            System.err.println("Error: " + e.getMessage());
         } finally {
             disconnect(conn);
         }
@@ -99,9 +98,7 @@ class DOSPluginUtil {
             return validConn;
 
         } catch ( IOException e) {
-            System.err.println("createConnection() Error: " + e.getMessage());
-            e.printStackTrace();
-
+            System.err.println("Error: " + e.getMessage() + ". Returning null");
             return null;
         }
     }
@@ -111,9 +108,7 @@ class DOSPluginUtil {
             URL request = new URL(protocol + "://" + immutableTriple.getMiddle() + API +  immutableTriple.getRight());
             return (HttpURLConnection) request.openConnection();
         } catch (IOException e) {
-            System.err.println("openURL() Error:" + e.getMessage());
-            e.printStackTrace();
-
+            System.err.println("Error:" + e.getMessage() + ". Returning null");
             return null;
         }
     }
@@ -122,7 +117,7 @@ class DOSPluginUtil {
         try {
             return Optional.ofNullable(conn.getInputStream());
         } catch (IOException e) {
-            System.err.println("downloadJSON() Error: " + e.getMessage());
+            System.err.println("Error: " + e.getMessage() + ". Returning empty");
             return Optional.empty();
         }
     }
@@ -137,9 +132,7 @@ class DOSPluginUtil {
             return content.toString();
 
         } catch (IOException e) {
-            System.err.println("readStream() Error: " + e.getMessage());
-            e.printStackTrace();
-
+            System.err.println("Error: " + e.getMessage() + ". Returning null");
             return null;
         }
     }

--- a/src/main/java/io/dockstore/provision/DOSPluginUtil.java
+++ b/src/main/java/io/dockstore/provision/DOSPluginUtil.java
@@ -53,7 +53,7 @@ class DOSPluginUtil {
             // dos://dos-dss.ucsc-cgp-dev.org/630d31c3-381e-488d-b639-ce5d047a0142?version=2018-05-26T134315.070662Z
             // or the new format
             // dos://dg.4503/630d31c3-381e-488d-b639-ce5d047a0142
-            // See if the Host portion starts with 'dg.<port>', 'dos' otherwise
+            // See if the Host portion starts with 'dg.<number>', 'dos' otherwise
             if (uri.getAuthority().startsWith("dg.")) {
                 return Optional.of(new ImmutableTriple<>(uri.getScheme(), DG_HOST, uri.getAuthority() + fullPath));
             } else if (!uri.getPath().equals("")) {

--- a/src/main/java/io/dockstore/provision/DOSPluginUtil.java
+++ b/src/main/java/io/dockstore/provision/DOSPluginUtil.java
@@ -1,11 +1,5 @@
 package io.dockstore.provision;
 
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.math.NumberUtils;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,6 +9,12 @@ import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import static java.net.HttpURLConnection.HTTP_OK;
 

--- a/src/main/java/io/dockstore/provision/DOSPluginUtil.java
+++ b/src/main/java/io/dockstore/provision/DOSPluginUtil.java
@@ -5,13 +5,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
-import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Lists;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -21,13 +21,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
 class DOSPluginUtil {
 
     private static final String API = "/ga4gh/dos/v1/dataobjects/";
-    private static final int SCHEME = 0;
-    private static final int HOST = 1;
-    private static final int PATH = 2;
-
     private static final String DG_HOST = "dataguids.org";
-    private static final int DG_PREFIX = 1;
-    private static final int DG_UUID = 2;
 
     // Package-private constructor
     DOSPluginUtil() {
@@ -40,18 +34,33 @@ class DOSPluginUtil {
      * @return the scheme, host, and path of the targetPath, or <code>Optional.empty()</code>
      */
     Optional<ImmutableTriple<String, String, String>> splitURI(String dosURI) {
-        if (Pattern.compile(":\\/\\/(.+)/").matcher(dosURI).find()){
-            List<String> split  = Lists.newArrayList(dosURI.split(":\\/\\/|/"));
-            // Find out if the path is of the DOS GUID old format
+        try {
+            URI uri = new URI(dosURI);
+
+            // If URI query exists, append '?' to the front
+            String query = uri.getQuery() != null ? "?" + uri.getQuery() : null;
+
+            // If URI fragment exists, append '#' to the front
+            String fragment = uri.getFragment() != null ? "#" + uri.getFragment() : null;
+
+            // Full path is joined together as /path[?query][#fragment]
+            String fullPath = String.join("",
+                    Stream.of(uri.getPath(), query, fragment)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()));
+
+            // Find out of the path is of the DOS GUID old format
             // dos://dos-dss.ucsc-cgp-dev.org/630d31c3-381e-488d-b639-ce5d047a0142?version=2018-05-26T134315.070662Z
             // or the new format
             // dos://dg.4503/630d31c3-381e-488d-b639-ce5d047a0142
-            // See if the Host portion starts with 'dg' and ends with a port number
-            List<String> hostSplit = Lists.newArrayList(split.get(HOST).split("\\.", 2));
-            if (hostSplit.size() > 1 && hostSplit.get(0).equals("dg") && NumberUtils.isNumber(hostSplit.get(1))) {
-                return Optional.of(new ImmutableTriple<>(split.get(SCHEME), DG_HOST, split.get(DG_PREFIX) + "/" + split.get(DG_UUID)));
+            // See if the Host portion starts with 'dg.<port>', 'dos' otherwise
+            if (uri.getAuthority().startsWith("dg.")) {
+                return Optional.of(new ImmutableTriple<>(uri.getScheme(), DG_HOST, uri.getAuthority() + fullPath));
+            } else if (!uri.getPath().equals("")) {
+                return Optional.of(new ImmutableTriple<>(uri.getScheme(), uri.getAuthority(), fullPath.substring(1)));
             }
-            return Optional.of(new ImmutableTriple<>(split.get(SCHEME), split.get(HOST), split.get(PATH)));
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
         }
         return Optional.empty();
     }

--- a/src/main/java/io/dockstore/provision/DOSPluginUtil.java
+++ b/src/main/java/io/dockstore/provision/DOSPluginUtil.java
@@ -1,7 +1,9 @@
 package io.dockstore.provision;
 
 import com.google.common.collect.Lists;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -11,14 +13,10 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-
-
-import org.apache.commons.lang3.math.NumberUtils;
 
 class DOSPluginUtil {
 
@@ -30,8 +28,6 @@ class DOSPluginUtil {
     private static final String DG_HOST = "dataguids.org";
     private static final int DG_PREFIX = 1;
     private static final int DG_UUID = 2;
-
-    private HttpURLConnection conn;
 
     // Package-private constructor
     DOSPluginUtil() {
@@ -66,56 +62,72 @@ class DOSPluginUtil {
      * @param immutableTriple The targetPath as an ImmutableTriple of <scheme, host, path>
      * @return The JSONObject containing the content of the JSON response, or <code>Optional.empty()</code>
      */
-    Optional<JSONObject> getResponse(ImmutableTriple<String, String, String> immutableTriple){
-        String content;
-        Optional<InputStream> JSONResponse;
-
+    Optional<JSONObject> getResponse(ImmutableTriple<String, String, String> immutableTriple) {
+        HttpURLConnection conn = createConnection(immutableTriple);
         try {
-            JSONResponse = downloadJSON(immutableTriple);
-            content = JSONResponse.map(this::readContent).orElse(null);
+            if (conn == null) {
+                return Optional.empty();
+            }
 
-            return Optional.of(new JSONObject(content));
-        } catch (Exception e) {
-            System.err.println("Plugin HttpURLConnection error: "  + e.getCause());
+            final Optional<InputStream> jsonResponse = downloadJSON(conn);
+            final String content = jsonResponse.map(this::readStream).orElse(null);
+
+            if (content != null) {
+                return Optional.of(new JSONObject(content));
+            }
+
+        } catch (JSONException e) {
+            System.err.println("getResponse() Error: " + e.getMessage());
             e.printStackTrace();
         } finally {
-            disconnect();
+            disconnect(conn);
         }
         return Optional.empty();
     }
 
-    Optional<InputStream> downloadJSON(ImmutableTriple<String, String, String> immutableTriple) {
+    HttpURLConnection createConnection(ImmutableTriple<String, String, String> immutableTriple) {
         try {
-            conn = createConnection("http", immutableTriple);
-            if (Objects.requireNonNull(conn).getResponseCode() != HTTP_OK) {
-                try {
-                    conn = createConnection("https", immutableTriple);
-                    if (Objects.requireNonNull(conn).getResponseCode() != HTTP_OK) {
-                        return Optional.empty();
-                    }
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    return Optional.empty();
+            HttpURLConnection validConn;
+            validConn = openURL("http", immutableTriple);       // Separate method for accurate unit testing
+
+            if (validConn == null || validConn.getResponseCode() != HTTP_OK) {
+                validConn = openURL("https", immutableTriple);
+                if (validConn == null || validConn.getResponseCode() != HTTP_OK) {
+                    return null;
                 }
             }
+            return validConn;
+
+        } catch ( IOException e) {
+            System.err.println("createConnection() Error: " + e.getMessage());
+            e.printStackTrace();
+
+            return null;
+        }
+    }
+
+    HttpURLConnection openURL(String protocol, ImmutableTriple<String, String, String> immutableTriple) {
+        try {
+            URL request = new URL(protocol + "://" + immutableTriple.getMiddle() + API +  immutableTriple.getRight());
+            return (HttpURLConnection) request.openConnection();
+        } catch (IOException e) {
+            System.err.println("openURL() Error:" + e.getMessage());
+            e.printStackTrace();
+
+            return null;
+        }
+    }
+
+    Optional<InputStream> downloadJSON(HttpURLConnection conn) {
+        try {
             return Optional.ofNullable(conn.getInputStream());
         } catch (IOException e) {
+            System.err.println("downloadJSON() Error: " + e.getMessage());
             return Optional.empty();
         }
     }
 
-    HttpURLConnection createConnection(String protocol, ImmutableTriple<String, String, String> immutableTriple) {
-        try {
-            URL request = new URL(protocol + "://" + immutableTriple.getMiddle() + API +  immutableTriple.getRight());
-            return (HttpURLConnection) request.openConnection();
-        } catch ( IOException e) {
-            System.err.println("ERROR opening HTTP URL Connection:" + protocol + "://" + immutableTriple.getMiddle() + API +  immutableTriple.getRight());
-            e.printStackTrace();
-        }
-        return null;
-    }
-
-    String readContent(InputStream stream) {
+    String readStream(InputStream stream) {
         try (BufferedReader in = new BufferedReader(new InputStreamReader(stream))){
             String line;
             StringBuilder content = new StringBuilder();
@@ -123,15 +135,18 @@ class DOSPluginUtil {
                 content.append(line);
             }
             return content.toString();
+
         } catch (IOException e) {
-            System.err.println("ERROR reading HTTP Response object.");
+            System.err.println("readStream() Error: " + e.getMessage());
             e.printStackTrace();
+
+            return null;
         }
-        return null;
     }
 
-    void disconnect() {
-        assert conn != null;
-        conn.disconnect();
+    void disconnect(HttpURLConnection conn) {
+        if (conn != null) {
+            conn.disconnect();
+        }
     }
 }

--- a/src/main/java/io/dockstore/provision/DOSPluginUtil.java
+++ b/src/main/java/io/dockstore/provision/DOSPluginUtil.java
@@ -98,7 +98,7 @@ class DOSPluginUtil {
             return validConn;
 
         } catch ( IOException e) {
-            System.err.println("Error: " + e.getMessage() + ". Returning null");
+            System.err.println("Error: " + e.getMessage());
             return null;
         }
     }
@@ -108,7 +108,7 @@ class DOSPluginUtil {
             URL request = new URL(protocol + "://" + immutableTriple.getMiddle() + API +  immutableTriple.getRight());
             return (HttpURLConnection) request.openConnection();
         } catch (IOException e) {
-            System.err.println("Error:" + e.getMessage() + ". Returning null");
+            System.err.println("Error:" + e.getMessage());
             return null;
         }
     }
@@ -117,7 +117,7 @@ class DOSPluginUtil {
         try {
             return Optional.ofNullable(conn.getInputStream());
         } catch (IOException e) {
-            System.err.println("Error: " + e.getMessage() + ". Returning empty");
+            System.err.println("Error: " + e.getMessage());
             return Optional.empty();
         }
     }
@@ -132,7 +132,7 @@ class DOSPluginUtil {
             return content.toString();
 
         } catch (IOException e) {
-            System.err.println("Error: " + e.getMessage() + ". Returning null");
+            System.err.println("Error: " + e.getMessage());
             return null;
         }
     }

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -129,13 +129,14 @@ public class DOSPluginUnitTest {
             "}" +
         "}");
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(mockInputStream));
         String line;
         StringBuilder content = new StringBuilder();
-        while ((line = in.readLine()) != null) {
-            content.append(line);
+
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(mockInputStream))) {
+            while ((line = in.readLine()) != null) {
+                content.append(line);
+            }
         }
-        in.close();
 
         JSONObject expectedJSON = new JSONObject(content.toString());
 
@@ -194,13 +195,14 @@ public class DOSPluginUnitTest {
             "}" +
         "}");
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(mockInputStream));
         String line;
         StringBuilder content = new StringBuilder();
-        while ((line = in.readLine()) != null) {
-            content.append(line);
+
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(mockInputStream))) {
+            while ((line = in.readLine()) != null) {
+                content.append(line);
+            }
         }
-        in.close();
 
         JSONObject expectedJSON = new JSONObject(content.toString());
 
@@ -255,13 +257,14 @@ public class DOSPluginUnitTest {
             "}" +
         "}");
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(mockInputStream));
         String line;
         StringBuilder content = new StringBuilder();
-        while ((line = in.readLine()) != null) {
-            content.append(line);
+
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(mockInputStream))) {
+            while ((line = in.readLine()) != null) {
+                content.append(line);
+            }
         }
-        in.close();
 
         JSONObject expectedJSON = new JSONObject(content.toString());
 

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -37,29 +37,17 @@ public class DOSPluginUnitTest {
     public void testPrepareDownload() {
         DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
         List<String> expected = new ArrayList<>();
-        String targetPath = "dos://dos-dss.ucsc-cgp-dev.org/630d31c3-381e-488d-b639-ce5d047a0142?version=2018-05-26T134315.070662Z";
-        expected.add("s3://cgp-commons-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai");
+        String targetPath = "dos://dg.4503/630d31c3-381e-488d-b639-ce5d047a0142";
         expected.add("gs://cgp-commons-multi-region-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai");
+        expected.add("s3://cgp-commons-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai");
         Assert.assertEquals(expected, dos.prepareDownload(targetPath));
     }
-
 
     @Test
     public void testPrepareDownloadReturnEmpty1() {
         DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
         String targetPath = "dos://dos-dss.ucsc-cgp-dev.org/fff5a29f-d184-4e3b-9c5b-6f44aea7f527?version=2018-02-28T033124.129027Zf";
         Assert.assertTrue(dos.prepareDownload(targetPath).isEmpty());
-    }
-
-
-    @Test
-    public void testPrepareDownload2() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
-        List<String> expected = new ArrayList<>();
-        String targetPath = "dos://dg.4503/630d31c3-381e-488d-b639-ce5d047a0142";
-        expected.add("gs://cgp-commons-multi-region-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai");
-        expected.add("s3://cgp-commons-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai");
-        Assert.assertEquals(expected, dos.prepareDownload(targetPath));
     }
 
 

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -71,6 +71,16 @@ public class DOSPluginUnitTest {
     }
 
     @Test
+    public void testSetConfigurationNoPreferences() {
+        Map<String, String> config = new HashMap<>();
+
+        List<String> expectedSchemes = new ArrayList<>();
+        dosPreProvision.setConfiguration(config);
+
+        Assert.assertEquals(expectedSchemes, dosPreProvision.preferredSchemes);
+    }
+
+    @Test
     public void testSchemesHandled() {
         Set<String> scheme = new HashSet<>(Collections.singletonList("dos"));
         Assert.assertEquals(scheme, dosPreProvision.schemesHandled());
@@ -207,8 +217,8 @@ public class DOSPluginUnitTest {
                 new ImmutableTriple<>("dos", "dataguids.org", "dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c");
 
         List<String> expected = new ArrayList<>();
-        expected.add("gs://gs-url-1/path");
-        expected.add("gs://gs-url-2/path");
+        expected.add("gs://gs-url/path1");
+        expected.add("gs://gs-url/path2");
         expected.add("s3://s3-url/path");
 
         InputStream mockInputStream = IOUtils.toInputStream(
@@ -229,13 +239,13 @@ public class DOSPluginUnitTest {
                 "\"updated\": \"2018-05-26T13:43:17.056871\"," +
                 "\"urls\": [" +
                     "{" +
-                        "\"url\": \"gs://gs-url-1/path\"" +
+                        "\"url\": \"gs://gs-url/path1\"" +
                     "}," +
                     "{" +
                         "\"url\": \"s3://s3-url/path\"" +
                     "}," +
                     "{" +
-                        "\"url\": \"gs://gs-url-2/path\"" +
+                        "\"url\": \"gs://gs-url/path2\"" +
                     "}" +
                 "]," +
                 "\"version\": \"89dfdc16\"" +

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -135,6 +135,8 @@ public class DOSPluginUnitTest {
         while ((line = in.readLine()) != null) {
             content.append(line);
         }
+        in.close();
+
         JSONObject expectedJSON = new JSONObject(content.toString());
 
         // Mock expected DOSPluginUtil object functionality when splitURI() and getResponse() are called
@@ -198,6 +200,7 @@ public class DOSPluginUnitTest {
         while ((line = in.readLine()) != null) {
             content.append(line);
         }
+        in.close();
 
         JSONObject expectedJSON = new JSONObject(content.toString());
 
@@ -258,6 +261,7 @@ public class DOSPluginUnitTest {
         while ((line = in.readLine()) != null) {
             content.append(line);
         }
+        in.close();
 
         JSONObject expectedJSON = new JSONObject(content.toString());
 

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 public class DOSPluginUnitTest {
 
-    @Mock (name = "pluginUtil")
+    @Mock (name = "DOS_PLUGIN_UTIL")
     DOSPluginUtil pluginUtil;
     @InjectMocks DOSPlugin.DOSPreProvision dosPreProvision;
 

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -28,8 +28,9 @@ import java.util.Set;
 public class DOSPluginUnitTest {
 
     @Mock (name = "dosPluginUtil")
-    DOSPluginUtil dosPluginUtil;
-    @InjectMocks DOSPlugin.DOSPreProvision dosPreProvision;
+    private DOSPluginUtil dosPluginUtil;
+    @InjectMocks
+    private DOSPlugin.DOSPreProvision dosPreProvision;
 
     @Before
     public void setup() {

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -1,8 +1,20 @@
 package io.dockstore.provision;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.json.JSONObject;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -12,65 +24,101 @@ import java.util.Set;
 
 public class DOSPluginUnitTest {
 
-    @Test
-    public void testDOSProvision() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
-    }
+    @Mock (name = "pluginUtil")
+    DOSPluginUtil pluginUtil;
+    @InjectMocks DOSPlugin.DOSPreProvision dosPreProvision;
 
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     public void testSchemesHandled() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
         Set<String> scheme = new HashSet<>(Collections.singletonList("dos"));
-        Assert.assertEquals(scheme, dos.schemesHandled());
+        Assert.assertEquals(scheme, dosPreProvision.schemesHandled());
     }
 
     @Test
     public void testSchemesHandledFailed() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
         Set<String> scheme = new HashSet<>(Collections.singletonList("fake"));
-        Assert.assertNotEquals(scheme, dos.schemesHandled());
+        Assert.assertNotEquals(scheme, dosPreProvision.schemesHandled());
     }
 
-
     @Test
-    public void testPrepareDownload() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
+    public void testPrepareDownload() throws IOException {
+        ImmutableTriple<String, String, String> split =
+                new ImmutableTriple<>("dos", "dataguids.org", "dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c");
+
         List<String> expected = new ArrayList<>();
-        String targetPath = "dos://dg.4503/630d31c3-381e-488d-b639-ce5d047a0142";
-        expected.add("gs://cgp-commons-multi-region-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai");
-        expected.add("s3://cgp-commons-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai");
-        Assert.assertEquals(expected, dos.prepareDownload(targetPath));
+        expected.add("gs://cgp-commons-multi-region-public/topmed_open_access/53ae11a8-ef4d-5aa6-9227-f372b422f5a1/NWD446684.recab.cram.crai");
+        expected.add("s3://cgp-commons-public/topmed_open_access/53ae11a8-ef4d-5aa6-9227-f372b422f5a1/NWD446684.recab.cram.crai");
+
+        InputStream mockStream = IOUtils.toInputStream(
+        "{" +
+                "\"data_object\": {" +
+                        "\"checksums\": [" +
+                                "{" +
+                                    "\"checksum\": \"bf140ba9778dd091d533c59d888c4463\"," +
+                                    "\"type\": \"md5\"" +
+                                "}" +
+                        "]," +
+                        "\"created\": \"2018-05-26T13:43:17.056861\"," +
+                        "\"description\": \"\"," +
+                        "\"id\": \"dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c\"," +
+                        "\"mime_type\": \"\"," +
+                        "\"name\": null," +
+                        "\"size\": 1503901," +
+                        "\"updated\": \"2018-05-26T13:43:17.056871\"," +
+                        "\"urls\": [" +
+                                "{" +
+                                        "\"url\": \"gs://cgp-commons-multi-region-public/topmed_open_access/53ae11a8-ef4d-5aa6-9227-f372b422f5a1/NWD446684.recab.cram.crai\"" +
+                                "}," +
+                                "{" +
+                                        "\"url\": \"s3://cgp-commons-public/topmed_open_access/53ae11a8-ef4d-5aa6-9227-f372b422f5a1/NWD446684.recab.cram.crai\"" +
+                                "}" +
+                        "]," +
+                        "\"version\": \"89dfdc16\"" +
+                "}" +
+        "}");
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(mockStream));
+        String line;
+        StringBuilder content = new StringBuilder();
+        while ((line = in.readLine()) != null) {
+            content.append(line);
+        }
+        JSONObject expectedJSON = new JSONObject(content.toString());
+
+        // Mock expected DOSPluginUtil object functionality when splitURI() and getResponse() are called
+        Mockito.when(pluginUtil.splitURI("dos://dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c")).thenReturn(java.util.Optional.ofNullable(split));
+        Mockito.when(pluginUtil.getResponse(split)).thenReturn(java.util.Optional.ofNullable(expectedJSON));
+
+        List<String> actual = dosPreProvision.prepareDownload("dos://dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c");
+        Assert.assertEquals(expected, actual);
     }
 
     @Test
     public void testPrepareDownloadReturnEmpty1() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
-        String targetPath = "dos://dos-dss.ucsc-cgp-dev.org/fff5a29f-d184-4e3b-9c5b-6f44aea7f527?version=2018-02-28T033124.129027Zf";
-        Assert.assertTrue(dos.prepareDownload(targetPath).isEmpty());
+        String targetPath = "dos://dos-dss.ucsc-cgp-dev.org/ffffffff";
+        Assert.assertTrue(dosPreProvision.prepareDownload(targetPath).isEmpty());
     }
-
 
     @Test
     public void testPrepareDownloadReturnEmpty2() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
         String targetPath = "dos://dg.4503/630d31c3-381e-488d-b639-ffffffffffff";
-        Assert.assertTrue(dos.prepareDownload(targetPath).isEmpty());
+        Assert.assertTrue(dosPreProvision.prepareDownload(targetPath).isEmpty());
     }
-
 
     @Test
     public void testPrepareDownloadReturnEmpty3() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
         String targetPath = "fake";
-        Assert.assertTrue(dos.prepareDownload(targetPath).isEmpty());
+        Assert.assertTrue(dosPreProvision.prepareDownload(targetPath).isEmpty());
     }
-
 
     @Test
     public void testPrepareDownloadReturnEmpty4() {
-        DOSPlugin.DOSPreProvision dos = new DOSPlugin.DOSPreProvision();
         String targetPath = "dos:/fake";
-        Assert.assertTrue(dos.prepareDownload(targetPath).isEmpty());
+        Assert.assertTrue(dosPreProvision.prepareDownload(targetPath).isEmpty());
     }
 }

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -1,16 +1,5 @@
 package io.dockstore.provision;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
-import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,6 +12,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 
 public class DOSPluginUnitTest {
@@ -43,6 +43,28 @@ public class DOSPluginUnitTest {
         config.put("scheme-preference", "gcs, s3, synapse");
 
         List<String> expectedSchemes = Arrays.asList("gcs", "s3", "synapse");
+        dosPreProvision.setConfiguration(config);
+
+        Assert.assertEquals(expectedSchemes, dosPreProvision.preferredSchemes);
+    }
+
+    @Test
+    public void testSetConfigurationNoSpaces() {
+        Map<String, String> config = new HashMap<>();
+        config.put("scheme-preference", "gcs,s3,synapse");
+
+        List<String> expectedSchemes = Arrays.asList("gcs", "s3", "synapse");
+        dosPreProvision.setConfiguration(config);
+
+        Assert.assertEquals(expectedSchemes, dosPreProvision.preferredSchemes);
+    }
+
+    @Test
+    public void testSetConfigurationVariableSpaces() {
+        Map<String, String> config = new HashMap<>();
+        config.put("scheme-preference", ",gcs,    s3,synapse,    , , foo");
+
+        List<String> expectedSchemes = Arrays.asList("gcs", "s3", "synapse", "foo");
         dosPreProvision.setConfiguration(config);
 
         Assert.assertEquals(expectedSchemes, dosPreProvision.preferredSchemes);

--- a/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUnitTest.java
@@ -24,8 +24,8 @@ import java.util.Set;
 
 public class DOSPluginUnitTest {
 
-    @Mock (name = "DOS_PLUGIN_UTIL")
-    DOSPluginUtil pluginUtil;
+    @Mock (name = "dosPluginUtil")
+    DOSPluginUtil dosPluginUtil;
     @InjectMocks DOSPlugin.DOSPreProvision dosPreProvision;
 
     @Before
@@ -54,7 +54,7 @@ public class DOSPluginUnitTest {
         expected.add("gs://cgp-commons-multi-region-public/topmed_open_access/53ae11a8-ef4d-5aa6-9227-f372b422f5a1/NWD446684.recab.cram.crai");
         expected.add("s3://cgp-commons-public/topmed_open_access/53ae11a8-ef4d-5aa6-9227-f372b422f5a1/NWD446684.recab.cram.crai");
 
-        InputStream mockStream = IOUtils.toInputStream(
+        InputStream mockInputStream = IOUtils.toInputStream(
         "{" +
                 "\"data_object\": {" +
                         "\"checksums\": [" +
@@ -82,7 +82,7 @@ public class DOSPluginUnitTest {
                 "}" +
         "}");
 
-        BufferedReader in = new BufferedReader(new InputStreamReader(mockStream));
+        BufferedReader in = new BufferedReader(new InputStreamReader(mockInputStream));
         String line;
         StringBuilder content = new StringBuilder();
         while ((line = in.readLine()) != null) {
@@ -91,8 +91,8 @@ public class DOSPluginUnitTest {
         JSONObject expectedJSON = new JSONObject(content.toString());
 
         // Mock expected DOSPluginUtil object functionality when splitURI() and getResponse() are called
-        Mockito.when(pluginUtil.splitURI("dos://dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c")).thenReturn(java.util.Optional.ofNullable(split));
-        Mockito.when(pluginUtil.getResponse(split)).thenReturn(java.util.Optional.ofNullable(expectedJSON));
+        Mockito.when(dosPluginUtil.splitURI("dos://dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c")).thenReturn(java.util.Optional.of(split));
+        Mockito.when(dosPluginUtil.getResponse(split)).thenReturn(java.util.Optional.of(expectedJSON));
 
         List<String> actual = dosPreProvision.prepareDownload("dos://dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c");
         Assert.assertEquals(expected, actual);

--- a/src/test/java/io/dockstore/provision/DOSPluginUtilUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUtilUnitTest.java
@@ -1,15 +1,15 @@
 package io.dockstore.provision;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.Optional;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.util.Optional;
 
 
 public class DOSPluginUtilUnitTest {

--- a/src/test/java/io/dockstore/provision/DOSPluginUtilUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUtilUnitTest.java
@@ -88,10 +88,11 @@ public class DOSPluginUtilUnitTest {
     @Test
     public void testCreateConnection() throws IOException {
         ImmutableTriple<String, String, String> split =
-                new ImmutableTriple<>("dos", "ec2-52-26-45-130.us-west-2.compute.amazonaws.com:8080", "911bda59-b6f9-4330-9543-c2bf96df1eca");
+                new ImmutableTriple<>("dos", "dos-dss.ucsc-cgp-dev.org", "630d31c3-381e-488d-b639-ce5d047a0142?version=2018-05-26T134315.070662Z");
 
         URL mockURL = new URL("http://" + split.getMiddle() + "/ga4gh/dos/v1/dataobjects/" + split.getRight());
         HttpURLConnection mockConn = (HttpURLConnection) mockURL.openConnection();
+        System.out.print(mockConn.toString());
         Assert.assertThat(mockConn.toString(), CoreMatchers.containsString(pluginUtil.createConnection("http", split).toString()));
     }
 

--- a/src/test/java/io/dockstore/provision/DOSPluginUtilUnitTest.java
+++ b/src/test/java/io/dockstore/provision/DOSPluginUtilUnitTest.java
@@ -7,12 +7,11 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Optional;
 
 
 public class DOSPluginUtilUnitTest {
@@ -20,69 +19,155 @@ public class DOSPluginUtilUnitTest {
     private static DOSPluginUtil pluginUtil = new DOSPluginUtil();
 
     @Test
-    public void testSplitUri() {
+    public void testSplitUriOldFormat() {
         String uri = "dos://dos-dss.ucsc-cgp-dev.org/fff5a29f-d184-4e3b-9c5b-6f44aea7f527?version=2018-02-28T033124.129027Zf";
         ImmutableTriple<String, String, String> split =
                 new ImmutableTriple<>("dos", "dos-dss.ucsc-cgp-dev.org", "fff5a29f-d184-4e3b-9c5b-6f44aea7f527?version=2018-02-28T033124.129027Zf");
-        Assert.assertEquals(split, pluginUtil.splitUri(uri).get());
+        Assert.assertEquals(split, pluginUtil.splitURI(uri).get());
+    }
+
+    @Test
+    public void testSplitUriNewFormat() {
+        String uri = "dos://dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c";
+        ImmutableTriple<String, String, String> split =
+                new ImmutableTriple<>("dos", "dataguids.org", "dg.4503/1aad0eb6-0d89-4fdd-976c-f9aa248fc88c");
+        Assert.assertEquals(split, pluginUtil.splitURI(uri).get());
+
     }
 
     @Test
     public void testSplitUriMalformedPath() {
         String uri = "fake:/host//uid";
-        Assert.assertFalse(pluginUtil.splitUri(uri).isPresent());
+        Assert.assertFalse(pluginUtil.splitURI(uri).isPresent());
     }
 
     @Test
     public void testSplitUriBadPath1() {
         String uri = "fake";
-        Assert.assertFalse(pluginUtil.splitUri(uri).isPresent());
+        Assert.assertFalse(pluginUtil.splitURI(uri).isPresent());
     }
 
     @Test
     public void testSplitUriBadPath2() {
         String uri = "fake://host";
-        Assert.assertFalse(pluginUtil.splitUri(uri).isPresent());
+        Assert.assertFalse(pluginUtil.splitURI(uri).isPresent());
     }
 
     @Test
-    public void testGrabJSONHttpStatusNot200() throws IOException {
+    public void testGetResponse() {
+        DOSPluginUtil spyPluginUtil = Mockito.spy(DOSPluginUtil.class);
+        ImmutableTriple<String, String, String> split =
+                new ImmutableTriple<>("dos", "dataguids.org", "dg.4503/b1266976-fd47-4a32-a7f4-d367d545abb2");
+
+        InputStream expectedResponse = IOUtils.toInputStream(
+        "{" +
+                "\"data_object\":{" +
+                        "\"checksums\":[" +
+                        "{" +
+                                "\"checksum\":\"2f160ab47e55d0e2f51b19264f917a30\"," +
+                                        "\"type\":\"md5\"" +
+                        "}" +
+                        "]," +
+                        "\"urls\":[" +
+                        "{" +
+                                "\"url\":\"gs://cgp-commons-multi-region-public/topmed_open_access/1111ec7b-675d-5c00-8aa4-7eea28f2b846/NWD480514.recab.cram.crai\"" +
+                        "}," +
+                        "{" +
+                                "\"url\":\"s3://cgp-commons-public/topmed_open_access/1111ec7b-675d-5c00-8aa4-7eea28f2b846/NWD480514.recab.cram.crai\"" +
+                        "}" +
+                        "]," +
+                        "\"size\":1416635," +
+                        "\"mime_type\":\"\"," +
+                        "\"created\":\"2018-05-26T13:43:17.443990\"," +
+                        "\"name\":null," +
+                        "\"description\":\"\"," +
+                        "\"id\":\"dg.4503/b1266976-fd47-4a32-a7f4-d367d545abb2\"," +
+                        "\"updated\":\"2018-05-26T13:43:17.443999\"," +
+                        "\"version\":\"e4a460cb\"" +
+                "}" +
+        "}");
+
+        // Mock downloadJSON() to return (non-empty) InputStream
+        Mockito.doReturn(Optional.of(expectedResponse)).when(spyPluginUtil).downloadJSON(split);
+        Mockito.doNothing().when(spyPluginUtil).disconnect();
+
+        Assert.assertTrue(spyPluginUtil.getResponse(split).isPresent());
+    }
+
+    @Test
+    public void testGetResponseReturnEmpty1() throws IOException {
         DOSPluginUtil spyPluginUtil = Mockito.spy(DOSPluginUtil.class);
         ImmutableTriple<String, String, String> split =
                 new ImmutableTriple<>("fake-scheme", "fake-host", "fake-path");
-
 
         // Create mock HttpURLConnection
         HttpURLConnection mockConn = Mockito.mock(HttpURLConnection.class);
         Mockito.when(mockConn.getResponseCode()).thenReturn(500);
 
-        // Return mockConnection (with mocked response code) when createConnection() is called
+        // Return mockConn (with mocked response code) when createConnection() is called
         Mockito.doReturn(mockConn).when(spyPluginUtil).createConnection("http", split);
-        Assert.assertFalse(spyPluginUtil.grabJSON(split).isPresent());
+        Assert.assertFalse(spyPluginUtil.getResponse(split).isPresent());
     }
 
     @Test
-    public void testGrabJSONHttpsStatusNot200() throws IOException {
+    public void testGetResponseReturnEmpty2() throws IOException {
         DOSPluginUtil spyPluginUtil = Mockito.spy(DOSPluginUtil.class);
         ImmutableTriple<String, String, String> split =
                 new ImmutableTriple<>("fake-scheme", "fake-host", "fake-path");
 
         // Create mock HttpURLConnection
         HttpURLConnection mockConn = Mockito.mock(HttpURLConnection.class);
-        Mockito.when(mockConn.getResponseCode()).thenReturn(500).thenReturn(500);
+        Mockito.when(mockConn.getResponseCode()).thenReturn(500).thenReturn(403);
 
         // Return mockConnection (with mocked response code) when createConnection() is called
         Mockito.doReturn(mockConn).when(spyPluginUtil).createConnection("http", split);
         Mockito.doReturn(mockConn).when(spyPluginUtil).createConnection("https", split);
 
-        Assert.assertFalse(spyPluginUtil.grabJSON(split).isPresent());
+        Assert.assertFalse(spyPluginUtil.getResponse(split).isPresent());
     }
 
     @Test
-    public void testGrabJSONBadURI() {
+    public void testGetResponseBadURI() {
         ImmutableTriple<String, String, String> split =
                 new ImmutableTriple<>("fake-scheme", "fake-host", "fake-path");
-        Assert.assertFalse(pluginUtil.grabJSON(split).isPresent());
+        Assert.assertFalse(pluginUtil.getResponse(split).isPresent());
+    }
+
+    @Test
+    public void testDownloadJSON() throws IOException {
+        DOSPluginUtil spyPluginUtil = Mockito.spy(DOSPluginUtil.class);
+        ImmutableTriple<String, String, String> split =
+                new ImmutableTriple<>("dos", "dataguids.org", "dg.4503/630d31c3-381e-488d-b639-ce5d047a0142");
+
+        // Mock createConnection() response with valid mocked InputStream obj
+        HttpURLConnection mockConn = Mockito.mock(HttpURLConnection.class);
+        InputStream mockInputStream = Mockito.mock(InputStream.class);
+
+        // Return valid connection when createConn() is called inside downloadJSON()
+        Mockito.when(mockConn.getResponseCode()).thenReturn(200);
+        Mockito.when(mockConn.getInputStream()).thenReturn(mockInputStream);
+
+        Mockito.doReturn(mockConn).when(spyPluginUtil).createConnection("http", split);
+
+        Assert.assertTrue(spyPluginUtil.downloadJSON(split).isPresent());
+    }
+
+    @Test
+    public void testDownloadJSONReturnEmpty() throws IOException {
+        DOSPluginUtil spyPluginUtil = Mockito.spy(DOSPluginUtil.class);
+        ImmutableTriple<String, String, String> split =
+                new ImmutableTriple<>("dos", "dataguids.org", "dg.4503/630d31c3-381e-488d-b639-ce5d047a0142");
+        // Construct URL https://dataguids.org/ga4gh/dos/v1/dataobjects/dg.4503/630d31c3-381e-488d-b639-ce5d047a0142
+
+        // Create mock HttpURLConnection
+        HttpURLConnection mockConn = Mockito.mock(HttpURLConnection.class);
+        Mockito.when(mockConn.getResponseCode()).thenReturn(500).thenReturn(403);
+
+        // Return mockConnection (with mocked response code) when createConnection() is called
+        Mockito.doReturn(mockConn).when(spyPluginUtil).createConnection("http", split);
+        Mockito.doReturn(mockConn).when(spyPluginUtil).createConnection("https", split);
+
+        Assert.assertFalse(spyPluginUtil.downloadJSON(split).isPresent());
     }
 
     @Test
@@ -92,7 +177,6 @@ public class DOSPluginUtilUnitTest {
 
         URL mockURL = new URL("http://" + split.getMiddle() + "/ga4gh/dos/v1/dataobjects/" + split.getRight());
         HttpURLConnection mockConn = (HttpURLConnection) mockURL.openConnection();
-        System.out.print(mockConn.toString());
         Assert.assertThat(mockConn.toString(), CoreMatchers.containsString(pluginUtil.createConnection("http", split).toString()));
     }
 
@@ -105,13 +189,16 @@ public class DOSPluginUtilUnitTest {
     }
 
     @Test
-    public void testReadResponse() throws IOException {
-        ImmutableTriple<String, String, String> split =
-                new ImmutableTriple<>("dos", "dataguids.org", "dg.4503/630d31c3-381e-488d-b639-ce5d047a0142");
-        // Construct URL https://dataguids.org/ga4gh/dos/v1/dataobjects/dg.4503/630d31c3-381e-488d-b639-ce5d047a0142
-        // This is a live URL and this test and others rely on it
-        HttpURLConnection actualConn = pluginUtil.createConnection("https", split);
-        InputStream expectedResponse = IOUtils.toInputStream(
+    public void testReadContent() throws IOException {
+        String expectedResponse = "{\"data_object\": {\"checksums\": [{\"checksum\": \"3b0f63a815384a3d44c61b4abd40caf9\", " +
+                "\"type\": \"md5\"}], \"created\": \"2018-05-26T13:43:15.070662\", \"description\": \"\", " +
+                "\"id\": \"dg.4503/630d31c3-381e-488d-b639-ce5d047a0142\", \"mime_type\": \"\", \"name\": null, " +
+                "\"size\": 2201638, \"updated\": \"2018-05-26T13:43:15.070672\", " +
+                "\"urls\": [{\"url\": \"gs://cgp-commons-multi-region-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai\"}, " +
+                "{\"url\": \"s3://cgp-commons-public/topmed_open_access/44a8837b-4456-5709-b56b-54e23000f13a/NWD100953.recab.cram.crai\"}], " +
+                "\"version\": \"2ba0ac25\"}}";
+
+        InputStream testInputStream = IOUtils.toInputStream(
         "{" +
                 "\"data_object\": {" +
                         "\"checksums\": [" +
@@ -139,14 +226,6 @@ public class DOSPluginUtilUnitTest {
                 "}" +
         "}");
 
-        HttpURLConnection mockConn = Mockito.mock(HttpURLConnection.class);
-        Mockito.when(mockConn.getInputStream()).thenReturn(expectedResponse);
-        BufferedReader bufferedReader = Mockito.spy(new BufferedReader(new InputStreamReader(mockConn.getInputStream ())));
-        String line;
-        StringBuilder mockContent = new StringBuilder();
-        while ((line = bufferedReader.readLine()) != null) {
-            mockContent.append(line);
-        }
-        Assert.assertEquals(mockContent.toString(), pluginUtil.readResponse(actualConn.getInputStream()));
+        Assert.assertEquals(expectedResponse, pluginUtil.readContent(testInputStream));
     }
 }


### PR DESCRIPTION
For ga4gh/dockstore#1482

Allows end users to specify scheme preferences in the `.dockstore/config` file when working with data-object-service URIs